### PR TITLE
Fix: Add Return Statement to Handle Invalid Input in configure Command

### DIFF
--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -37,6 +37,7 @@ var configureCmd = &cobra.Command{
 		userChoice, err := strconv.Atoi(input)
 		if err != nil {
 			fmt.Println("Error converting input to integer")
+			return
 		}
 
 		ManageCloudProvider(userChoice - 1)


### PR DESCRIPTION
#### Summary
This pull request addresses a critical issue in the `configure` command where invalid user input was not handled properly, potentially causing the program to behave unexpectedly or crash.

#### Problem
In the original implementation, if the user provided invalid input that could not be converted to an integer, the error was logged using `fmt.Println`, but the program execution continued. This caused the `ManageCloudProvider` function to be called with an invalid `userChoice` value, leading to undefined behavior.

#### Solution
A `return` statement was added immediately after logging the error when the input conversion fails. This ensures that the program does not proceed with invalid input and avoids unintended execution of the `ManageCloudProvider` function.

#### Changes Made
- Added a `return` statement in the error-handling block of the `Run` function to terminate execution when invalid input is detected.

#### Code Example

**Before:**
```go
userChoice, err := strconv.Atoi(input)
if err != nil {
    fmt.Println("Error converting input to integer")
}
ManageCloudProvider(userChoice - 1)
```

**After:**
```go
userChoice, err := strconv.Atoi(input)
if err != nil {
    fmt.Println("Error converting input to integer")
    return
}
ManageCloudProvider(userChoice - 1)
```

#### Impact
- Prevents the program from continuing execution with invalid input.
- Improves robustness and user experience by properly handling errors.

Please review the changes and let me know if further modifications are needed.